### PR TITLE
[yes] use fixed size byte array to improve perfromance

### DIFF
--- a/yes/yes.go
+++ b/yes/yes.go
@@ -30,7 +30,6 @@ var (
 	version = flag.BoolP("version", "v", false, "")
 
 	LineFeed = []byte("\n")
-	Space    = []byte(" ")
 )
 
 func main() {
@@ -50,15 +49,14 @@ func main() {
 		args = []string{"y"}
 	}
 
-	for {
-		for i, arg := range args {
-			os.Stdout.WriteString(arg)
+	// Fixed []byte array will increase performance by x~100
+	arg := make([]byte, 4096)
+	copy(arg[:], args[0])
+	// Add \n at the end of the of "y" or argument
+	arg = append(arg[:], LineFeed...)
 
-			if i == len(args)-1 {
-				os.Stdout.Write(LineFeed)
-			} else {
-				os.Stdout.Write(Space)
-			}
-		}
+	for {
+		os.Stdout.Write(arg)
 	}
+
 }


### PR DESCRIPTION
Using a fixed size byte array increases performance by x100 

```shell
$ go run yes.go n | pv -r > /dev/null
[1.07MiB/s]

$ go run yes.go n | pv -r > /dev/null
[2.08GiB/s]```